### PR TITLE
Add libeis-devel to BuildRequires

### DIFF
--- a/gamescope.spec
+++ b/gamescope.spec
@@ -33,6 +33,7 @@ BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  glm-devel
 BuildRequires:  google-benchmark-devel
+BuildRequires:  libeis-devel
 BuildRequires:  libXmu-devel
 BuildRequires:  libXcursor-devel
 BuildRequires:  pkgconfig(libdisplay-info)


### PR DESCRIPTION
Fixes builds that take place after support for XTest/Input emulation with libei was added.