### PR TITLE
Set CAP_SYS_NICE bit to eip to improve performance

### DIFF
--- a/gamescope.spec
+++ b/gamescope.spec
@@ -132,7 +132,7 @@ export PKG_CONFIG_PATH=pkgconfig
 %files
 %license LICENSE
 %doc README.md
-%{_bindir}/gamescope
+%caps(cap_sys_nice=eip) %{_bindir}/gamescope
 %{_libdir}/libVkLayer_FROG_gamescope_wsi_*.so
 %{_datadir}/vulkan/implicit_layer.d/VkLayer_FROG_gamescope_wsi.*.json
 


### PR DESCRIPTION
This is suggested pretty much universally, so setting this seems like a good idea.

This should set the bit when the package is installed, stopping users from having to set it themselves.