### PR TITLE
reduce build download size

### DIFF
--- a/gamescope.spec
+++ b/gamescope.spec
@@ -98,10 +98,9 @@ BuildRequires:  pkgconfig(xwayland)
 %{name} is the micro-compositor optimized for running video games on Wayland.
 
 %prep
-git clone %{URL}
+git clone --revision=%{commit} --depth=1 %{URL}
 cd gamescope
-git checkout %{commit}
-git submodule update --init --recursive
+git submodule update --init --recursive --depth=1
 
 # Install stub pkgconfig file
 mkdir -p pkgconfig


### PR DESCRIPTION
limit history to only 1 commit to reduce download size and build time